### PR TITLE
Fixed GPUBuffers ReleaseMemory not freeing VBO

### DIFF
--- a/src/core/gpu/gpu_buffers.cpp
+++ b/src/core/gpu/gpu_buffers.cpp
@@ -30,9 +30,9 @@ void GPUBuffers::ReleaseMemory()
 {
     if (m_size)
     {
-        m_size = 0;
         glDeleteVertexArrays(1, &m_VAO);
         glDeleteBuffers(m_size, m_VBO);
+        m_size = 0;
     }
 }
 


### PR DESCRIPTION
m_size was reset before actually freeing the buffers, resulting in 0 VBOs being freed.
Loosely tested on Linux, but I think this is the intended code.