### PR TITLE
Update VertexShader.glsl to have the correct type for material_shininess

### DIFF
--- a/src/lab_m1/lab7/shaders/VertexShader.glsl
+++ b/src/lab_m1/lab7/shaders/VertexShader.glsl
@@ -15,7 +15,7 @@ uniform vec3 light_position;
 uniform vec3 eye_position;
 uniform float material_kd;
 uniform float material_ks;
-uniform int material_shininess;
+uniform unsigned int material_shininess;
 
 uniform vec3 object_color;
 


### PR DESCRIPTION
The parameter materialShininess from Lab7 is of type unsigned int (as the shininess coefficient is normally a positive value), so the corresponding variable in VertexShader.glsl should have the same type to avoid confusion (and possibly visual glitches) when transmitting the value to the vertex shader.