### PR TITLE
Initialized elapsedTime member variable of WindowObject

### DIFF
--- a/src/core/window/window_object.cpp
+++ b/src/core/window/window_object.cpp
@@ -72,6 +72,8 @@ WindowObject::WindowObject(WindowProperties properties)
     memset(keyScanCode, 0, 512);
 
     SetWindowCallbacks();
+
+    elapsedTime = Engine::GetElapsedTime();
 }
 
 


### PR DESCRIPTION
It was causing the deltaTime for the first frame to have an undefined value (in the OnInputUpdate function)