### PR TITLE
fix(core): add nullptr check to mesh destructor to avoid segfault on mesh deletion

### DIFF
--- a/src/core/gpu/mesh.cpp
+++ b/src/core/gpu/mesh.cpp
@@ -22,6 +22,9 @@ Mesh::Mesh(std::string meshID)
     useMaterial = true;
     glDrawMode = GL_TRIANGLES;
     buffers = new GPUBuffers();
+
+    this->anim = nullptr;
+    this->rootNode = nullptr;
 }
 
 
@@ -31,8 +34,12 @@ Mesh::~Mesh()
     meshEntries.clear();
     SAFE_FREE(buffers);
 
-    ClearAnimations(anim, numAnim);
-    ClearRootNode(rootNode);
+    if (anim != nullptr) {
+        ClearAnimations(anim, numAnim);
+    }
+    if (rootNode != nullptr) {
+        ClearRootNode(rootNode);
+    }
 }
 
 


### PR DESCRIPTION
# Bug overview

If the user attempts to delete a mesh using the `delete` keyword, the program will always segfault if `InitFromScene()` was not called. This issue is prevalent if the user implements scene-changes, or has short-lived objects that need their own mesh (e.g. bullets with random colors).

The cause of this issue is that the mesh destructor attempts to call `ClearAnimations` and `ClearRootNode` even if these two objects have not been initialized (currently they are only set in the `InitFromScene()` function). The simple fix for this is to check before-hand if these functions need to be called.

The reason this might not have popped up as an issue before is because the default scene behaviour isn't to delete all values from the `meshes` hash map when the scene's destructor is called. For the lab assignments, this memory leak isn't a big issue.

# How to replicate

A simple way to replicate this is to modify `lab1.cpp` as such:
```cpp
void Lab1::Init()
{
    // ...
    {
        Mesh* mesh = new Mesh("box");
        mesh->LoadMesh(PATH_JOIN(window->props.selfDir, RESOURCE_PATH::MODELS, "primitives"), "box.obj");
        meshes[mesh->GetMeshID()] = mesh;
    }

    // -=-=-=-=-= ADD THIS =-=-=-=-=-=-
    {
        Mesh* mesh = new Mesh("box2");
        delete mesh;
    }
    // -=-=-=-=-= ADD THIS =-=-=-=-=-=-

   // ...
}
```

And use this scene in `main.cpp`:
```cpp

    // Create a new 3D world and start running it
    World *world = new m1::Lab1();
   
```