### PR TITLE
[PGAPI] Lab6 texture bug on non Windows systems

### DIFF
--- a/src/lab_m2/lab6/lab6.cpp
+++ b/src/lab_m2/lab6/lab6.cpp
@@ -98,7 +98,7 @@ void Lab6::Init()
         PATH_JOIN(texturePath, "neg_y.png"),
         PATH_JOIN(texturePath, "neg_z.png"));
 
-    TextureManager::LoadTexture(PATH_JOIN(window->props.selfDir, RESOURCE_PATH::MODELS), "characters", "archer", "Akai_E_Espiritu.fbm", "akai_diffuse.png");
+    TextureManager::LoadTexture(PATH_JOIN(window->props.selfDir, RESOURCE_PATH::MODELS, "characters", "archer", "Akai_E_Espiritu.fbm"), "akai_diffuse.png");
 
     // Create the framebuffer on which the scene is rendered from the perspective of the mesh
     // Texture size must be cubic
@@ -174,7 +174,7 @@ void Lab6::Update(float deltaTimeSeconds)
             glUniformMatrix4fv(shader->loc_projection_matrix, 1, GL_FALSE, glm::value_ptr(projection));
 
             glActiveTexture(GL_TEXTURE0);
-            glBindTexture(GL_TEXTURE_2D, TextureManager::GetTexture("Akai_E_Espiritu.fbm\\akai_diffuse.png")->GetTextureID());
+            glBindTexture(GL_TEXTURE_2D, TextureManager::GetTexture("akai_diffuse.png")->GetTextureID());
             glUniform1i(glGetUniformLocation(shader->program, "texture_1"), 0);
 
             glUniform1i(glGetUniformLocation(shader->program, "cube_draw"), 0);
@@ -230,7 +230,7 @@ void Lab6::Update(float deltaTimeSeconds)
         glUniformMatrix4fv(shader->loc_projection_matrix, 1, GL_FALSE, glm::value_ptr(camera->GetProjectionMatrix()));
 
         glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, TextureManager::GetTexture("Akai_E_Espiritu.fbm\\akai_diffuse.png")->GetTextureID());
+        glBindTexture(GL_TEXTURE_2D, TextureManager::GetTexture("akai_diffuse.png")->GetTextureID());
         glUniform1i(glGetUniformLocation(shader->program, "texture_1"), 0);
 
         meshes["archer"]->Render();


### PR DESCRIPTION
### Bug Report
The issue is in m2::Lab6

When the archer texture is loaded, the parameters are not set correctly.
```cpp
TextureManager::LoadTexture(PATH_JOIN(window->props.selfDir, RESOURCE_PATH::MODELS), "characters", "archer", "Akai_E_Espiritu.fbm", "akai_diffuse.png");
```
First, the path is not correct. PATH should contain everything up to the file name, but it is closed after the models folder.

The code works on Windows because when the texture is loaded, it is done like this:
```cpp
glBindTexture(GL_TEXTURE_2D, TextureManager::GetTexture("Akai_E_Espiritu.fbm\\akai_diffuse.png")->GetTextureID());
```

The texture is there because it is loaded when the model is loaded. But in this manner, the path is not correct for non-Windows systems. PATH_JOIN should be used or the initial load should be corrected. I opted for the last one since it would be quite difficult for students to find out where is the texture loaded.
![image](https://github.com/user-attachments/assets/3ed1ac38-0034-4442-b1ac-4dcebaf610d4)

