### PR TITLE
[PGAPI] Solved a bug in lab7

### DIFF
--- a/src/lab_m2/lab7/lab7.cpp
+++ b/src/lab_m2/lab7/lab7.cpp
@@ -32,8 +32,8 @@ void Lab7::Init()
     // Create a shader program for rendering to texture
     {
         Shader* shader = new Shader("Skinning");
-        shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "Lab7", "shaders", "VertexShader.glsl"), GL_VERTEX_SHADER);
-        shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "Lab7", "shaders", "FragmentShader.glsl"), GL_FRAGMENT_SHADER);
+        shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "lab7", "shaders", "VertexShader.glsl"), GL_VERTEX_SHADER);
+        shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "lab7", "shaders", "FragmentShader.glsl"), GL_FRAGMENT_SHADER);
         shader->CreateAndLink();
         shaders[shader->GetName()] = shader;
     }


### PR DESCRIPTION
### Bug Report

The issue is in m2::Lab7

When the lab's shader is created, the path is not set correctly.
```cpp
 shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "Lab7", "shaders", "VertexShader.glsl"), GL_VERTEX_SHADER);
 shader->AddShader(PATH_JOIN(window->props.selfDir, SOURCE_PATH::M2, "Lab7", "shaders", "FragmentShader.glsl"),GL_FRAGMENT_SHADER);
```
The lab's folder name is with **lower case "lab7"** and the path **is set with upper case "Lab7"**. Because of this, on **case sensitive file systems** (on Unix systems), the path is not found and the shader is not created.